### PR TITLE
Add Complete the Look products feature

### DIFF
--- a/wp-content/plugins/complete-look/complete-look.php
+++ b/wp-content/plugins/complete-look/complete-look.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Plugin Name: Complete the Look
+ * Description: Adds Complete the Look products for WooCommerce and Elementor widget integration.
+ * Version: 1.0.0
+ * Author: OpenAI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class CAL_Complete_Look {
+    public function __construct() {
+        add_action( 'add_meta_boxes', [ $this, 'add_metabox' ] );
+        add_action( 'save_post_product', [ $this, 'save_metabox' ] );
+    }
+
+    /**
+     * Register metabox.
+     */
+    public function add_metabox() {
+        add_meta_box(
+            'cal-complete-look',
+            __( 'Complete the Look', 'complete-look' ),
+            [ $this, 'render_metabox' ],
+            'product',
+            'side',
+            'default'
+        );
+    }
+
+    /**
+     * Render metabox content.
+     *
+     * @param WP_Post $post Current post object.
+     */
+    public function render_metabox( $post ) {
+        wp_nonce_field( 'cal_save_look_products', 'cal_look_products_nonce' );
+
+        $selected = get_post_meta( $post->ID, 'look_products', true );
+        $selected = is_array( $selected ) ? $selected : [];
+        ?>
+        <select class="wc-product-search" multiple="multiple" style="width:100%" name="look_products[]" data-placeholder="<?php esc_attr_e( 'Search for a product…', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations">
+            <?php
+            foreach ( $selected as $product_id ) {
+                $product = wc_get_product( $product_id );
+                if ( $product ) {
+                    echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . wp_kses_post( $product->get_formatted_name() ) . '</option>';
+                }
+            }
+            ?>
+        </select>
+        <p class="description"><?php esc_html_e( 'Select products that complete the look.', 'complete-look' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Save metabox data.
+     *
+     * @param int $post_id Product ID.
+     */
+    public function save_metabox( $post_id ) {
+        if ( ! isset( $_POST['cal_look_products_nonce'] ) || ! wp_verify_nonce( $_POST['cal_look_products_nonce'], 'cal_save_look_products' ) ) {
+            return;
+        }
+
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+
+        if ( isset( $_POST['look_products'] ) && is_array( $_POST['look_products'] ) ) {
+            $ids = array_filter( array_map( 'intval', (array) $_POST['look_products'] ) );
+            update_post_meta( $post_id, 'look_products', $ids );
+        } else {
+            delete_post_meta( $post_id, 'look_products' );
+        }
+    }
+}
+
+new CAL_Complete_Look();

--- a/wp-content/themes/woodmart/inc/integrations/elementor/elements/products/class-products.php
+++ b/wp-content/themes/woodmart/inc/integrations/elementor/elements/products/class-products.php
@@ -145,10 +145,11 @@ class Products extends Widget_Base {
 						'recently_viewed'    => esc_html__( 'Recently Viewed Products', 'woodmart' ),
 					),
 					array(
-						'single_product' => array(
-							'related' => esc_html__( 'Related (Single product)', 'woodmart' ),
-							'upsells' => esc_html__( 'Upsells (Single product)', 'woodmart' ),
-						),
+                                               'single_product' => array(
+                                                       'related'       => esc_html__( 'Related (Single product)', 'woodmart' ),
+                                                       'upsells'       => esc_html__( 'Upsells (Single product)', 'woodmart' ),
+                                                       'complete_look' => esc_html__( 'Complete the Look', 'woodmart' ),
+                                               ),
 						'cart'           => array(
 							'cross-sells' => esc_html__( 'Cross Sells', 'woodmart' ),
 						),

--- a/wp-content/themes/woodmart/inc/integrations/elementor/elements/products/products.php
+++ b/wp-content/themes/woodmart/inc/integrations/elementor/elements/products/products.php
@@ -266,16 +266,31 @@ if ( ! function_exists( 'woodmart_elementor_products_template' ) ) {
 			}
 		}
 
-		if ( 'related' === $settings['post_type'] ) {
-			if ( $product && is_object( $product ) ) {
-				$query_args['post__in']  = array_merge( array( 0 ), wc_get_related_products( $product->get_id(), $query_args['posts_per_page'], $product->get_upsell_ids() ) );
-				$query_args['post_type'] = array( 'product', 'product_variation' );
+                if ( 'related' === $settings['post_type'] ) {
+                        if ( $product && is_object( $product ) ) {
+                                $query_args['post__in']  = array_merge( array( 0 ), wc_get_related_products( $product->get_id(), $query_args['posts_per_page'], $product->get_upsell_ids() ) );
+                                $query_args['post_type'] = array( 'product', 'product_variation' );
 
-				if ( ! isset( $query_args['post__in'][1] ) && 0 === $query_args['post__in'][0] ) {
-					return false;
-				}
-			}
-		}
+                                if ( ! isset( $query_args['post__in'][1] ) && 0 === $query_args['post__in'][0] ) {
+                                        return false;
+                                }
+                        }
+                }
+
+                if ( 'complete_look' === $settings['post_type'] ) {
+                        if ( $product && is_object( $product ) ) {
+                                $look_ids = get_post_meta( $product->get_id(), 'look_products', true );
+                                $look_ids = is_array( $look_ids ) ? array_filter( array_map( 'intval', $look_ids ) ) : array();
+
+                                if ( $look_ids ) {
+                                        $query_args['post__in']  = $look_ids;
+                                        $query_args['orderby']   = 'post__in';
+                                        $query_args['post_type'] = array( 'product', 'product_variation' );
+                                } else {
+                                        return false;
+                                }
+                        }
+                }
 
 		if ( 'cross-sells' === $settings['post_type'] ) {
 			if ( is_object( WC()->cart )  ) {


### PR DESCRIPTION
## Summary
- add a Complete the Look metabox to WooCommerce products that saves selected product IDs
- extend the wd_products Elementor widget with a Complete the Look data source
- query and display selected products on single product layouts

## Testing
- `php -l wp-content/plugins/complete-look/complete-look.php`
- `php -l wp-content/themes/woodmart/inc/integrations/elementor/elements/products/class-products.php`
- `php -l wp-content/themes/woodmart/inc/integrations/elementor/elements/products/products.php`


------
https://chatgpt.com/codex/tasks/task_e_688e4af5e048832cac9285d533d2b7c9