### PR TITLE
Rename FBT to looks and sync product look tags

### DIFF
--- a/wp-content/plugins/woodmart-core/class-post-types.php
+++ b/wp-content/plugins/woodmart-core/class-post-types.php
@@ -111,27 +111,27 @@ class Post_Types {
 			return;
 		}
 
-		register_post_type(
-			'woodmart_woo_fbt',
-			array(
-				'label'              => esc_html__( 'Frequently Bought Together', 'woodmart' ),
-				'labels'             => array(
-					'name'          => esc_html__( 'Frequently Bought Together', 'woodmart' ),
-					'singular_name' => esc_html__( 'Frequently Bought Together', 'woodmart' ),
-					'menu_name'     => esc_html__( 'Frequently Bought Together', 'woodmart' ),
-					'add_new'       => esc_html__( 'Add New', 'woodmart' ),
-					'add_new_item'  => esc_html__( 'Add New', 'woodmart' ),
-				),
-				'supports'           => array( 'title' ),
-				'hierarchical'       => false,
-				'public'             => true,
-				'show_in_menu'       => 'edit.php?post_type=product',
-				'publicly_queryable' => false,
-				'show_in_rest'       => true,
-				'capability_type'    => 'product',
-			)
-		);
-	}
+               register_post_type(
+                       'woodmart_woo_fbt',
+                       array(
+                               'label'              => esc_html__( 'Looks', 'woodmart' ),
+                               'labels'             => array(
+                                       'name'          => esc_html__( 'Looks', 'woodmart' ),
+                                       'singular_name' => esc_html__( 'Look', 'woodmart' ),
+                                       'menu_name'     => esc_html__( 'Looks', 'woodmart' ),
+                                       'add_new'       => esc_html__( 'Add New', 'woodmart' ),
+                                       'add_new_item'  => esc_html__( 'Add New', 'woodmart' ),
+                               ),
+                               'supports'           => array( 'title' ),
+                               'hierarchical'       => false,
+                               'public'             => true,
+                               'show_in_menu'       => 'edit.php?post_type=product',
+                               'publicly_queryable' => false,
+                               'show_in_rest'       => true,
+                               'capability_type'    => 'product',
+                       )
+               );
+       }
 
 	/**
 	 * Register Dynamic Pricing & Discounts post type.

--- a/wp-content/themes/woodmart-child/inc/la_look_tag.php
+++ b/wp-content/themes/woodmart-child/inc/la_look_tag.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Look taxonomy and sync with Woodmart bundles.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Register custom taxonomy for product looks.
+add_action( 'init', function() {
+    register_taxonomy(
+        'product_look',
+        'product',
+        array(
+            'labels' => array(
+                'name'          => __( 'Looks', 'likeangel' ),
+                'singular_name' => __( 'Look', 'likeangel' ),
+            ),
+            'public'       => true,
+            'show_ui'      => true,
+            'show_in_rest' => true,
+            'hierarchical' => false,
+            'rewrite'      => array( 'slug' => 'look' ),
+        )
+    );
+} );
+
+/**
+ * Sync product look terms when Woodmart bundle is saved.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ */
+function la_sync_bundle_look_terms( $post_id, $post ) {
+    if ( wp_is_post_revision( $post_id ) || 'woodmart_woo_fbt' !== $post->post_type ) {
+        return;
+    }
+
+    // Ensure term exists for this bundle.
+    $term_slug = 'look-' . $post_id;
+    $term_name = $post->post_title;
+
+    $term      = term_exists( $term_slug, 'product_look' );
+    if ( $term ) {
+        $term_id = (int) $term['term_id'];
+        wp_update_term( $term_id, 'product_look', array( 'name' => $term_name ) );
+    } else {
+        $term_id = wp_insert_term( $term_name, 'product_look', array( 'slug' => $term_slug ) );
+        if ( is_wp_error( $term_id ) ) {
+            return;
+        }
+        $term_id = (int) $term_id['term_id'];
+    }
+
+    // Collect product IDs from bundle meta.
+    $products    = get_post_meta( $post_id, '_woodmart_fbt_products', true );
+    $product_ids = array();
+
+    if ( is_array( $products ) ) {
+        foreach ( $products as $product ) {
+            if ( ! empty( $product['id'] ) ) {
+                $product_ids[] = (int) $product['id'];
+            }
+        }
+    }
+
+    // Assign term to all products in bundle.
+    foreach ( $product_ids as $pid ) {
+        wp_set_object_terms( $pid, $term_id, 'product_look', true );
+    }
+
+    // Remove term from products no longer in bundle.
+    $attached = get_objects_in_term( $term_id, 'product_look' );
+    foreach ( $attached as $object_id ) {
+        if ( ! in_array( (int) $object_id, $product_ids, true ) ) {
+            wp_remove_object_terms( $object_id, $term_id, 'product_look' );
+        }
+    }
+
+    // Delete term if no products left.
+    $attached = get_objects_in_term( $term_id, 'product_look' );
+    if ( empty( $attached ) ) {
+        wp_delete_term( $term_id, 'product_look' );
+    }
+}
+add_action( 'save_post_woodmart_woo_fbt', 'la_sync_bundle_look_terms', 10, 2 );
+
+/**
+ * Cleanup term when bundle deleted.
+ *
+ * @param int $post_id Post ID.
+ */
+function la_delete_bundle_look_term( $post_id ) {
+    $post = get_post( $post_id );
+    if ( ! $post || 'woodmart_woo_fbt' !== $post->post_type ) {
+        return;
+    }
+
+    $term_slug = 'look-' . $post_id;
+    $term      = term_exists( $term_slug, 'product_look' );
+    if ( $term ) {
+        $term_id = (int) $term['term_id'];
+
+        $attached = get_objects_in_term( $term_id, 'product_look' );
+        foreach ( $attached as $object_id ) {
+            wp_remove_object_terms( $object_id, $term_id, 'product_look' );
+        }
+        wp_delete_term( $term_id, 'product_look' );
+    }
+}
+add_action( 'before_delete_post', 'la_delete_bundle_look_term' );
+
+// Elementor query integration.
+add_filter( 'elementor/woocommerce/product_query_type', function ( $types ) {
+    $types['look'] = __( 'Look', 'likeangel' );
+    return $types;
+} );
+
+add_action( 'elementor/element/woocommerce-products/section_query/before_section_end', function( $element ) {
+    $terms   = get_terms( array( 'taxonomy' => 'product_look', 'hide_empty' => false ) );
+    $options = array();
+    if ( ! is_wp_error( $terms ) ) {
+        foreach ( $terms as $term ) {
+            $options[ $term->slug ] = $term->name;
+        }
+    }
+
+    $element->add_control(
+        'look_tag',
+        array(
+            'label'     => __( 'Look', 'likeangel' ),
+            'type'      => \Elementor\Controls_Manager::SELECT2,
+            'options'   => $options,
+            'label_block' => true,
+            'condition' => array( 'query_type' => 'look' ),
+        )
+    );
+} , 10, 2 );
+
+add_action( 'elementor/query/look', function( $wp_query, $widget ) {
+    $slug = $widget->get_settings( 'look_tag' );
+    if ( empty( $slug ) ) {
+        return;
+    }
+
+    $tax_query = array(
+        array(
+            'taxonomy' => 'product_look',
+            'field'    => 'slug',
+            'terms'    => $slug,
+        ),
+    );
+    $wp_query->set( 'tax_query', $tax_query );
+}, 10, 2 );

--- a/wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-controls.php
+++ b/wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-controls.php
@@ -185,11 +185,11 @@ class Controls extends Singleton {
 	 * @return array
 	 */
 	public function product_data_tabs( $tabs ) {
-		$tabs['woodmart_bought_together'] = array(
-			'label'    => esc_html__( 'Frequently Bought Together', 'woodmart' ),
-			'target'   => 'woodmart_bought_together',
-			'priority' => 80,
-		);
+               $tabs['woodmart_bought_together'] = array(
+                       'label'    => esc_html__( 'Look', 'woodmart' ),
+                       'target'   => 'woodmart_bought_together',
+                       'priority' => 80,
+               );
 
 		return $tabs;
 	}
@@ -232,9 +232,9 @@ class Controls extends Singleton {
 						<input type="hidden" class="xts-product-bundles-id" name="xts_product_bundles_id" value="<?php echo esc_attr( implode( ',', $bundles_id ) ); ?>" data-product-id="<?php the_ID(); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'woodmart_product_bundles_settings' ) ); ?>">
 					</p>
 				</div>
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=woodmart_woo_fbt' ) ); ?>">
-					<?php esc_html_e( 'Open bundles manager', 'woodmart' ); ?>
-				</a>
+                               <a href="<?php echo esc_url( admin_url( 'edit.php?post_type=woodmart_woo_fbt' ) ); ?>">
+                                       <?php esc_html_e( 'Open Looks manager', 'woodmart' ); ?>
+                               </a>
 			</div>
 		</div>
 		<?php
@@ -248,13 +248,13 @@ class Controls extends Singleton {
 	 * @return array
 	 */
 	public function edit_columns( $columns ) {
-		return array(
-			'cb'               => '<input type="checkbox" />',
-			'title'            => esc_html__( 'Title', 'woodmart' ),
-			'primary_products' => esc_html__( 'Products containing this bundle', 'woodmart' ),
-			'bundle_products'  => esc_html__( 'Bundle includes', 'woodmart' ),
-			'date'             => esc_html__( 'Date', 'woodmart' ),
-		);
+               return array(
+                       'cb'               => '<input type="checkbox" />',
+                       'title'            => esc_html__( 'Title', 'woodmart' ),
+                       'primary_products' => esc_html__( 'Products containing this look', 'woodmart' ),
+                       'bundle_products'  => esc_html__( 'Look includes', 'woodmart' ),
+                       'date'             => esc_html__( 'Date', 'woodmart' ),
+               );
 	}
 
 	/**

--- a/wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-main.php
+++ b/wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-main.php
@@ -49,10 +49,10 @@ class Main extends Singleton {
 	public function add_options() {
 		Options::add_field(
 			array(
-				'id'          => 'bought_together_enabled',
-				'name'        => esc_html__( 'Enable "Frequently bought together"', 'woodmart' ),
-				'hint'        => wp_kses( '<img data-src="' . WOODMART_TOOLTIP_URL . 'enable-frequently-bought-together.jpg" alt="">', true ),
-				'description' => wp_kses( __( 'You can configure your bundles in Dashboard -> Products -> Frequently Bought Together. Read more information in our <a href="https://xtemos.com/docs-topic/frequently-bought-together/" target="_blank">documentation</a>.', 'woodmart' ), true ),
+                               'id'          => 'bought_together_enabled',
+                               'name'        => esc_html__( 'Enable "Looks"', 'woodmart' ),
+                               'hint'        => wp_kses( '<img data-src="' . WOODMART_TOOLTIP_URL . 'enable-frequently-bought-together.jpg" alt="">', true ),
+                               'description' => wp_kses( __( 'You can configure your bundles in Dashboard -> Products -> Looks. Read more information in our <a href="https://xtemos.com/docs-topic/frequently-bought-together/" target="_blank">documentation</a>.', 'woodmart' ), true ),
 				'type'        => 'switcher',
 				'section'     => 'bought_together_section',
 				'default'     => '1',

--- a/wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-table.php
+++ b/wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-table.php
@@ -104,8 +104,8 @@ class Bundles_Table extends \WP_List_Table {
 	 * @return array
 	 */
 	public function get_columns() {
-		$data['name']     = esc_html__( 'Bundles name', 'woodmart' );
-		$data['products'] = esc_html__( 'Products', 'woodmart' );
+               $data['name']     = esc_html__( 'Look name', 'woodmart' );
+               $data['products'] = esc_html__( 'Products', 'woodmart' );
 
 		return $data;
 	}
@@ -154,6 +154,6 @@ class Bundles_Table extends \WP_List_Table {
 	 * Render if no items.
 	 */
 	public function no_items() {
-		esc_html_e( 'No bundles found.', 'woodmart' );
+               esc_html_e( 'No looks found.', 'woodmart' );
 	}
 }


### PR DESCRIPTION
## Summary
- Rename "Frequently Bought Together" admin menu and tabs to "Looks"
- Add `product_look` taxonomy and auto-sync it with Woodmart bundles
- Allow Elementor Products widget to filter by look tags

## Testing
- `php -l wp-content/plugins/woodmart-core/class-post-types.php`
- `php -l wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-main.php`
- `php -l wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-controls.php`
- `php -l wp-content/themes/woodmart/inc/integrations/woocommerce/modules/frequently-bought-together/class-table.php`
- `php -l wp-content/themes/woodmart-child/inc/la_look_tag.php`